### PR TITLE
Add login authentication and server endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
@@ -14,6 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "server": "node server.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+app.use(express.json());
+
+// Simple in-memory user store for demo purposes
+const USERS = {
+  admin: 'password',
+};
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (USERS[username] && USERS[username] === password) {
+    const token = jwt.sign(
+      { username },
+      process.env.JWT_SECRET || 'supersecret',
+      { expiresIn: '1h' }
+    );
+    return res.json({ token });
+  }
+  res.status(401).json({ message: 'Invalid credentials' });
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server listening on ${PORT}`);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import LoadingOverlay from './components/LoadingOverlay';
 import ProgressIndicator from './components/ProgressIndicator';
 import Footer from './components/Footer';
 import ErrorBanner from './components/ErrorBanner';
+import Login from './components/Login';
 
 const AdAnalyzerUI = () => {
 
@@ -157,8 +158,10 @@ const AdAnalyzerUI = () => {
       }
 
       // Din riktiga n8n webhook URL
+      const token = localStorage.getItem('token');
       const response = await fetch(webhookUrl, {
         method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
         body: formData,
       });
 
@@ -261,6 +264,13 @@ const AdAnalyzerUI = () => {
   );
 };
 function App() {
-return <AdAnalyzerUI />;
+  const [isAuthenticated, setIsAuthenticated] = useState(() => !!localStorage.getItem('token'));
+
+  if (!isAuthenticated) {
+    return <Login onSuccess={() => setIsAuthenticated(true)} />;
+  }
+
+  return <AdAnalyzerUI />;
 }
+
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,6 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 
+beforeEach(() => {
+  window.localStorage.setItem('token', 'test');
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
 test('renders Viva Impact Check heading', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /viva impact check/i });

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+function Login({ onSuccess }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) {
+        throw new Error('Login failed');
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      if (onSuccess) {
+        onSuccess(data.token);
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', width: '300px', gap: '12px' }}>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <div style={{ color: 'red' }}>{error}</div>}
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- add `Login` component to collect credentials and store token
- gate analyzer UI behind `isAuthenticated` state and include token on requests
- implement Express `/api/login` issuing JWT tokens and expose server script

## Testing
- `npm install express jsonwebtoken` *(fails: 403 Forbidden)*
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68c809d7d17c832db621a8d03836f647