### PR TITLE
Handle aborted token verification

### DIFF
--- a/apps/web/src/providers/AuthProvider.js
+++ b/apps/web/src/providers/AuthProvider.js
@@ -84,6 +84,9 @@ export const AuthProvider = ({ children }) => {
         setUser(data?.user ?? null);
         return data?.user ?? null;
       } catch (error) {
+        if (error?.name === 'AbortError') {
+          return null;
+        }
         console.error('Verifiering av auth-token misslyckades', error);
         clearSession();
         throw error;
@@ -209,9 +212,10 @@ export const AuthProvider = ({ children }) => {
       isAuthenticated: Boolean(token),
       isLoading,
       signInWithGoogle,
-      signOut
+      signOut,
+      verifyToken
     }),
-    [isLoading, signInWithGoogle, signOut, token, user]
+    [isLoading, signInWithGoogle, signOut, token, user, verifyToken]
   );
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/apps/web/src/providers/AuthProvider.test.js
+++ b/apps/web/src/providers/AuthProvider.test.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from './AuthProvider';
+
+const AuthStateObserver = React.forwardRef((_, ref) => {
+  const auth = useAuth();
+  React.useImperativeHandle(ref, () => auth, [auth]);
+  return null;
+});
+
+const STORAGE_KEY = 'viva-auth-token';
+
+describe('AuthProvider verifyToken', () => {
+  const originalVerifyUrl = process.env.REACT_APP_AUTH_VERIFY_URL;
+  const originalAbortController = global.AbortController;
+
+  afterEach(() => {
+    process.env.REACT_APP_AUTH_VERIFY_URL = originalVerifyUrl;
+    global.AbortController = originalAbortController;
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('keeps auth state when verification request is aborted', async () => {
+    process.env.REACT_APP_AUTH_VERIFY_URL = 'https://example.com/verify';
+
+    const controllers = [];
+    class MockAbortSignal {
+      constructor() {
+        this.aborted = false;
+        this.listeners = new Set();
+      }
+
+      addEventListener(event, handler) {
+        if (event === 'abort') {
+          this.listeners.add(handler);
+        }
+      }
+
+      removeEventListener(event, handler) {
+        if (event === 'abort') {
+          this.listeners.delete(handler);
+        }
+      }
+    }
+
+    class MockAbortController {
+      constructor() {
+        this.signal = new MockAbortSignal();
+        controllers.push(this);
+      }
+
+      abort() {
+        if (this.signal.aborted) {
+          return;
+        }
+        this.signal.aborted = true;
+        this.signal.listeners.forEach((handler) => handler());
+      }
+    }
+
+    global.AbortController = MockAbortController;
+
+    const token = 'valid-token';
+    const user = { name: 'Testare' };
+
+    const fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user })
+    });
+
+    fetchMock.mockImplementationOnce((_, options = {}) =>
+      new Promise((resolve, reject) => {
+        const { signal } = options;
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            const abortError = new Error('Aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+        }
+      })
+    );
+
+    const authRef = React.createRef();
+
+    render(
+      <AuthProvider>
+        <AuthStateObserver ref={authRef} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(authRef.current).toBeTruthy());
+
+    await act(async () => {
+      const result = await authRef.current.verifyToken(token);
+      expect(result).toEqual(user);
+    });
+
+    await waitFor(() => {
+      expect(authRef.current.token).toBe(token);
+      expect(authRef.current.user).toEqual(user);
+      expect(authRef.current.isLoading).toBe(false);
+    });
+
+    window.localStorage.setItem(STORAGE_KEY, token);
+
+    let abortingVerificationPromise;
+    await act(async () => {
+      abortingVerificationPromise = authRef.current.verifyToken(token);
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      const activeController = controllers[controllers.length - 1];
+      activeController.abort();
+    });
+
+    let abortedResult;
+    await act(async () => {
+      abortedResult = await abortingVerificationPromise;
+    });
+
+    expect(abortedResult).toBeNull();
+
+    await waitFor(() => expect(authRef.current.isLoading).toBe(false));
+
+    expect(authRef.current.token).toBe(token);
+    expect(authRef.current.user).toEqual(user);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe(token);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent `verifyToken` from clearing the session or throwing when the fetch request ends with an `AbortError`
- expose `verifyToken` on the auth context so tests can trigger verification directly
- add a unit test that aborts an in-flight verification and ensures the token and user state persist

## Testing
- npm run test:web

------
https://chatgpt.com/codex/tasks/task_b_68d1502fcf40832d9621b85da659d1a0