### PR TITLE
fix: make shared vite config node-compatible

### DIFF
--- a/packages/configs/vite.config.shared.ts
+++ b/packages/configs/vite.config.shared.ts
@@ -34,6 +34,11 @@ const workspaceAliases = Object.fromEntries(
 
 const sharedConfig = {
   plugins: [react()],
+  esbuild: {
+    include: /src\/.*\.js$/,
+    loader: 'jsx',
+    exclude: [],
+  },
   server: {
     fs: {
       allow: [monorepoRoot],

--- a/packages/configs/vite.config.shared.ts
+++ b/packages/configs/vite.config.shared.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import react from '@vitejs/plugin-react';
-import { defineConfig, mergeConfig, type UserConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vite';
 
 const packageDir = fileURLToPath(new URL('.', import.meta.url));
 const monorepoRoot = path.resolve(packageDir, '..', '..');
@@ -20,19 +20,19 @@ const workspaceAliases = Object.fromEntries(
 
       if (!fs.existsSync(packageJsonPath)) return [];
 
-      const { name } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
-        name?: string;
-      };
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      const name = packageJson?.name;
 
       if (!name) return [];
 
       const sourceDir = path.join(packageRoot, 'src');
+      const resolvedPath = fs.existsSync(sourceDir) ? sourceDir : packageRoot;
 
-      return [[name, fs.existsSync(sourceDir) ? sourceDir : packageRoot]];
+      return [[name, resolvedPath]];
     }),
-) as Record<string, string>;
+);
 
-const sharedConfig: UserConfig = {
+const sharedConfig = {
   plugins: [react()],
   server: {
     fs: {
@@ -44,7 +44,7 @@ const sharedConfig: UserConfig = {
   },
 };
 
-export const withSharedConfig = (config: UserConfig = {}) =>
+export const withSharedConfig = (config = {}) =>
   defineConfig(mergeConfig(sharedConfig, config));
 
 export default defineConfig(sharedConfig);


### PR DESCRIPTION
## Summary
- remove TypeScript-only syntax from the shared Vite config so Cloudflare's Node runtime can parse it
- keep the shared configuration helper exports while using runtime-safe JSON parsing

## Testing
- npm run build:web *(fails: vite not found in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d459742940832d90531311e3e0e720